### PR TITLE
Adds No-RAG mode for direct LLM conversations

### DIFF
--- a/AI/Embeddings/SemanticEmbeddingService.cs
+++ b/AI/Embeddings/SemanticEmbeddingService.cs
@@ -34,6 +34,14 @@ public class SemanticEmbeddingService : ITextEmbeddingGenerationService
     /// - all-MiniLM-L6-v2: 384 dims, fast (fallback)
     /// - all-mpnet-base-v2: 768 dims, best quality (recommended)
     /// </summary>
+    /// <param name="modelPath">Required. Path to the ONNX model file. Must be provided via configuration.</param>
+    /// <param name="vocabPath">Required. Path to the vocabulary file. Must be provided via configuration.</param>
+    /// <param name="embeddingDimension">Optional. The dimension of the embedding vectors. Default is 768.</param>
+    /// <param name="debugMode">Optional. Enable debug logging. Default is false.</param>
+    /// <remarks>
+    /// BREAKING CHANGE: modelPath and vocabPath are now required parameters (previously had default values).
+    /// Callers must explicitly provide these paths, typically from AppConfiguration.
+    /// </remarks>
     public SemanticEmbeddingService(
         string modelPath,
         string vocabPath,

--- a/AI/Embeddings/SemanticEmbeddingService.cs
+++ b/AI/Embeddings/SemanticEmbeddingService.cs
@@ -35,8 +35,8 @@ public class SemanticEmbeddingService : ITextEmbeddingGenerationService
     /// - all-mpnet-base-v2: 768 dims, best quality (recommended)
     /// </summary>
     public SemanticEmbeddingService(
-        string modelPath,
-        string vocabPath,
+        string modelPath = "models/all-mpnet-base-v2.onnx",
+        string vocabPath = "models/vocab.txt",
         int embeddingDimension = 768,
         bool debugMode = false)
     {

--- a/OfflineAI.Tests/Services/VectorMemoryQueryMatchingTests.cs
+++ b/OfflineAI.Tests/Services/VectorMemoryQueryMatchingTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using Entities;
 using Application.AI.Embeddings;
 using Services.Memory;
@@ -14,13 +15,21 @@ namespace OfflineAI.Tests.Services;
 /// </summary>
 public class VectorMemoryQueryMatchingTests
 {
-    private readonly SemanticEmbeddingService _embeddingService;
-    private VectorMemory _vectorMemory;
+    private readonly SemanticEmbeddingService? _embeddingService;
+    private VectorMemory? _vectorMemory;
 
     public VectorMemoryQueryMatchingTests()
     {
-        var modelPath = @"d:\tinyllama\models\all-MiniLM-L6-v2\model.onnx";
-        var vocabPath = @"d:\tinyllama\models\all-MiniLM-L6-v2\vocab.txt";
+        // Use environment variables or skip if paths don't exist
+        var modelPath = Environment.GetEnvironmentVariable("TEST_MODEL_PATH") ?? @"d:\tinyllama\models\all-MiniLM-L6-v2\model.onnx";
+        var vocabPath = Environment.GetEnvironmentVariable("TEST_VOCAB_PATH") ?? @"d:\tinyllama\models\all-MiniLM-L6-v2\vocab.txt";
+        
+        // Skip initialization if model files don't exist (tests will be skipped via test attribute)
+        if (!File.Exists(modelPath) || !File.Exists(vocabPath))
+        {
+            return;
+        }
+        
         _embeddingService = new SemanticEmbeddingService(modelPath, vocabPath, embeddingDimension: 384, debugMode: false);
         _vectorMemory = new VectorMemory(_embeddingService, "test_collection");
     }

--- a/OfflineAI.Tests/Services/VectorMemoryQueryMatchingTests.cs
+++ b/OfflineAI.Tests/Services/VectorMemoryQueryMatchingTests.cs
@@ -20,7 +20,8 @@ public class VectorMemoryQueryMatchingTests
     public VectorMemoryQueryMatchingTests()
     {
         var modelPath = @"d:\tinyllama\models\all-MiniLM-L6-v2\model.onnx";
-        _embeddingService = new SemanticEmbeddingService(modelPath, embeddingDimension: 384);
+        var vocabPath = @"d:\tinyllama\models\all-MiniLM-L6-v2\vocab.txt";
+        _embeddingService = new SemanticEmbeddingService(modelPath, vocabPath, embeddingDimension: 384, debugMode: false);
         _vectorMemory = new VectorMemory(_embeddingService, "test_collection");
     }
 

--- a/OfflineAI/Modes/RunVectorMemoryWithDatabaseMode.cs
+++ b/OfflineAI/Modes/RunVectorMemoryWithDatabaseMode.cs
@@ -574,7 +574,7 @@ internal static class RunVectorMemoryWithDatabaseMode
     {
         config.Debug.EnableRagMode = !config.Debug.EnableRagMode;
         
-        DisplayService.WriteLine($"\n[*] RAG Mode: {(config.Debug.EnableRagMode ? "ENABLED ✓" : "DISABLED ✗")}");
+        DisplayService.WriteLine($"\n[*] RAG Mode: {(config.Debug.EnableRagMode ? "ENABLED 🔍" : "DISABLED 💬")}");
         
         if (config.Debug.EnableRagMode)
         {

--- a/OfflineAI/Modes/RunVectorMemoryWithDatabaseMode.cs
+++ b/OfflineAI/Modes/RunVectorMemoryWithDatabaseMode.cs
@@ -572,6 +572,9 @@ internal static class RunVectorMemoryWithDatabaseMode
 
     private static void HandleToggleRagCommand(AppConfiguration config)
     {
+        // Note: This intentionally mutates the shared AppConfiguration.Debug.EnableRagMode
+        // to allow runtime toggling of RAG mode. The change affects new queries only,
+        // not in-flight operations. This is by design for interactive CLI usage.
         config.Debug.EnableRagMode = !config.Debug.EnableRagMode;
         
         DisplayService.WriteLine($"\n[*] RAG Mode: {(config.Debug.EnableRagMode ? "ENABLED 🔍" : "DISABLED 💬")}");

--- a/OfflineAI/Program.cs
+++ b/OfflineAI/Program.cs
@@ -73,7 +73,8 @@ namespace OfflineAI
                         new SemanticEmbeddingService(
                             appConfig.Embedding.ModelPath,
                             appConfig.Embedding.VocabPath,
-                            appConfig.Embedding.Dimension));
+                            appConfig.Embedding.Dimension,
+                            appConfig.Debug.EnableDebugMode));
                     
                     services.AddSingleton<ITextEmbeddingGenerationService>(provider => 
                         provider.GetRequiredService<SemanticEmbeddingService>());

--- a/OfflineAI/Program.cs
+++ b/OfflineAI/Program.cs
@@ -30,13 +30,6 @@ namespace OfflineAI
         static IHostBuilder CreateHostBuilder(string[] args)
         {
             return Host.CreateDefaultBuilder(args)
-                // Host.CreateDefaultBuilder already configures:
-                // - appsettings.json
-                // - appsettings.{Environment}.json  
-                // - User Secrets (in Development)
-                // - Environment Variables
-                // - Command Line Arguments
-                // So we don't need to add them again!
                 .ConfigureServices((context, services) =>
                 {
                     // Bind configuration sections
@@ -122,24 +115,6 @@ namespace OfflineAI
                     DisplayService.WriteLine($"   - {error}");
                 }
                 
-                // Show what environment we're running in
-                var environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") 
-                                  ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
-                                  ?? "Production";
-                DisplayService.WriteLine($"\n📊 Current Environment: {environment}");
-                
-                if (environment != "Development")
-                {
-                    DisplayService.WriteLine("\n⚠️  User Secrets are only loaded in Development environment!");
-                    DisplayService.WriteLine("   Set environment variable: DOTNET_ENVIRONMENT=Development");
-                }
-                
-                DisplayService.WriteLine("\n📝 Please configure using:");
-                DisplayService.WriteLine("   1. User Secrets: dotnet user-secrets set \"AppConfiguration:Llm:ExecutablePath\" \"d:\\\\tinyllama\\\\llama-cli.exe\"");
-                DisplayService.WriteLine("   2. appsettings.json: Copy appsettings.example.json and fill in your paths");
-                DisplayService.WriteLine("   3. Environment Variables: Set APPCONFIGURATION__LLM__EXECUTABLEPATH=...");
-                DisplayService.WriteLine("   4. Set DOTNET_ENVIRONMENT=Development to use User Secrets");
-                DisplayService.WriteLine("\nPress any key to exit...");
                 Console.ReadKey();
                 Environment.Exit(1);
             }

--- a/OfflineAI/Program.cs
+++ b/OfflineAI/Program.cs
@@ -152,7 +152,7 @@ namespace OfflineAI
                 proc.WaitForExit(3000);
 
                 var text = (stdout + "\n" + stderr).ToLowerInvariant();
-                string backend = null!;
+                string? backend = null;
                 if (text.Contains("cublas") || text.Contains("cuda")) backend = "CUDA";
                 else if (text.Contains("hipblas") || text.Contains("rocm")) backend = "ROCm";
                 else if (text.Contains("metal")) backend = "Metal";
@@ -169,7 +169,7 @@ namespace OfflineAI
                     DisplayService.WriteLine("ℹ️ Llama runtime backend: not detected from --version output");
                 }
             }
-            catch
+            catch (Exception ex) when (ex is System.ComponentModel.Win32Exception || ex is InvalidOperationException || ex is System.IO.IOException)
             {
                 // Fail silent; do not block startup if detection fails
             }
@@ -188,7 +188,7 @@ namespace OfflineAI
                     DisplayService.WriteLine($"🧠 LLM model: {modelName}{typePart} [file: {modelFile}]");
                 }
             }
-            catch
+            catch (Exception ex) when (ex is ArgumentException || ex is System.IO.IOException || ex is System.IO.PathTooLongException)
             {
                 // Ignore failure to fetch model info
             }

--- a/OfflineAI/appsettings.json
+++ b/OfflineAI/appsettings.json
@@ -28,5 +28,5 @@
     "UseDatabasePersistence": true,
     "AutoInitializeDatabase": true,
     "UseEntityFramework": false
-  }
+  },
 }

--- a/OfflineAI/appsettings.json
+++ b/OfflineAI/appsettings.json
@@ -19,6 +19,7 @@
     },
     "Debug": {
       "EnableDebugMode": false,
+      "EnableRagMode": true,
       "CollectionName": "game-rules-mpnet"
     }
   },

--- a/OfflineAI/appsettings.json
+++ b/OfflineAI/appsettings.json
@@ -28,5 +28,5 @@
     "UseDatabasePersistence": true,
     "AutoInitializeDatabase": true,
     "UseEntityFramework": false
-  },
+  }
 }

--- a/RAGTesting/Services/DisplayService.cs
+++ b/RAGTesting/Services/DisplayService.cs
@@ -211,10 +211,20 @@ public static class DisplayService
     public static void ShowQualityDistribution(TestSummary summary, Func<string, int> getQualityScore)
     {
         Console.WriteLine("QUALITY DISTRIBUTION:");
-        foreach (var kvp in summary.QualityDistribution.OrderByDescending(x => getQualityScore(x.Key)))
+        if (summary.SuccessfulTests == 0)
         {
-            var percentage = (double)kvp.Value / summary.SuccessfulTests * 100;
-            Console.WriteLine($"  {kvp.Key}: {kvp.Value} ({percentage:F1}%)");
+            foreach (var kvp in summary.QualityDistribution.OrderByDescending(x => getQualityScore(x.Key)))
+            {
+                Console.WriteLine($"  {kvp.Key}: {kvp.Value} (0.0%)");
+            }
+        }
+        else
+        {
+            foreach (var kvp in summary.QualityDistribution.OrderByDescending(x => getQualityScore(x.Key)))
+            {
+                var percentage = (double)kvp.Value / summary.SuccessfulTests * 100;
+                Console.WriteLine($"  {kvp.Key}: {kvp.Value} ({percentage:F1}%)");
+            }
         }
         Console.WriteLine();
     }

--- a/RAGTesting/Services/DisplayService.cs
+++ b/RAGTesting/Services/DisplayService.cs
@@ -1,0 +1,295 @@
+using RAGTesting.Models;
+
+namespace RAGTesting.Services;
+
+/// <summary>
+/// Service for handling console display in RAG testing system.
+/// Centralizes all console UI logic for better maintainability.
+/// </summary>
+public static class DisplayService
+{
+    #region Headers and Banners
+
+    public static void ShowHeader()
+    {
+        Console.WriteLine("???????????????????????????????????????????????????????????????????");
+        Console.WriteLine("?           RAG Quality Testing System                       ?");
+        Console.WriteLine("?           Testing Semantic Search & Retrieval             ?");
+        Console.WriteLine("???????????????????????????????????????????????????????????????????");
+        Console.WriteLine();
+    }
+
+    #endregion
+
+    #region Configuration and Initialization
+
+    public static void ShowEnvironment(string environment)
+    {
+        Console.WriteLine($"?? Environment: {environment}");
+    }
+
+    public static void ShowConfigurationSourcesHeader()
+    {
+        Console.WriteLine("?? Configuration sources:");
+    }
+
+    public static void ShowConfigurationSource(string providerName)
+    {
+        Console.WriteLine($"   - {providerName}");
+    }
+
+    public static void ShowConfigurationHeader()
+    {
+        Console.WriteLine($"\n?? Loaded configuration:");
+    }
+
+    public static void ShowConfigurationValue(string key, string value)
+    {
+        Console.WriteLine($"   {key}: '{value}'");
+    }
+
+    public static void ShowConfigurationValueInt(string key, int value)
+    {
+        Console.WriteLine($"   {key}: {value}");
+    }
+
+    public static void ShowConfigurationError(List<string> errors)
+    {
+        Console.WriteLine("\n? Configuration Error:");
+        foreach (var error in errors)
+        {
+            Console.WriteLine($"   - {error}");
+        }
+        
+        Console.WriteLine("\n?? Please configure using:");
+        Console.WriteLine("   1. User Secrets: dotnet user-secrets set \"AppConfiguration:Embedding:ModelPath\" \"path\"");
+        Console.WriteLine("   2. appsettings.json");
+        Console.WriteLine("   3. Environment Variables");
+    }
+
+    #endregion
+
+    #region Test Loading
+
+    public static void ShowNoTestQueriesFound()
+    {
+        Console.WriteLine("? No test queries found in test-queries.json");
+    }
+
+    public static void ShowLoadedTestQueries(int count)
+    {
+        Console.WriteLine($"? Loaded {count} test queries");
+        Console.WriteLine();
+    }
+
+    #endregion
+
+    #region Database Loading
+
+    public static void ShowLoadingEmbeddings(string collectionName)
+    {
+        Console.WriteLine($"?? Loading embeddings from database (collection: {collectionName})...");
+    }
+
+    public static void ShowNoFragmentsFound()
+    {
+        Console.WriteLine("??  No fragments found in database!");
+        Console.WriteLine("   Run the main OfflineAI application to import game rules first.");
+    }
+
+    public static void ShowLoadedFragments(int count)
+    {
+        Console.WriteLine($"? Loaded {count} fragments with embeddings");
+    }
+
+    public static void ShowVectorMemoryReady(int count)
+    {
+        Console.WriteLine($"? Vector memory ready with {count} fragments");
+        Console.WriteLine();
+    }
+
+    #endregion
+
+    #region Test Execution
+
+    public static void ShowRunningTestsHeader()
+    {
+        Console.WriteLine("?? Running RAG quality tests...");
+        Console.WriteLine();
+    }
+
+    public static void ShowTestHeader(string id, string description, string query, string? expectedGame, double minimumRelevance)
+    {
+        Console.WriteLine($"\n[TEST] Running: {id} - {description}");
+        Console.WriteLine($"   Query: \"{query}\"");
+        Console.WriteLine($"   Expected Game: {expectedGame ?? "(any)"}");
+        Console.WriteLine($"   Minimum Relevance: {minimumRelevance:F2}");
+    }
+
+    public static void ShowExecutingSearch()
+    {
+        Console.WriteLine($"   ?? Executing search...");
+    }
+
+    public static void ShowNoResults()
+    {
+        Console.WriteLine($"   ?? No results returned");
+    }
+
+    public static void ShowRetrievedCharacters(int length)
+    {
+        Console.WriteLine($"   ? Retrieved {length} characters");
+    }
+
+    public static void ShowParsedFragments(int count)
+    {
+        Console.WriteLine($"   ? Parsed {count} fragments");
+    }
+
+    public static void ShowTestException(Exception ex)
+    {
+        Console.WriteLine($"   ? Exception: {ex.Message}");
+        Console.WriteLine($"   Stack trace: {ex.StackTrace}");
+    }
+
+    #endregion
+
+    #region Test Results
+
+    public static void ShowTestFailed(string errorMessage)
+    {
+        Console.WriteLine($"  ? FAILED: {errorMessage}");
+    }
+
+    public static void ShowTestResult(TestResult result)
+    {
+        var icon = result.PassedMinimumThreshold ? "?" : "??";
+        Console.WriteLine($"  {icon} Quality: {result.QualityRating}");
+        Console.WriteLine($"     Max Relevance: {result.MaxRelevance:F3} (threshold: {result.MinimumThreshold:F2})");
+        Console.WriteLine($"     Avg Relevance: {result.AverageRelevance:F3}");
+        Console.WriteLine($"     Keyword Match: {result.KeywordsFound}/{result.KeywordsExpected} ({result.KeywordMatchRate:P0})");
+        Console.WriteLine($"     Execution: {result.ExecutionTime.TotalMilliseconds:F0}ms");
+
+        if (result.RetrievedFragments.Any())
+        {
+            Console.WriteLine($"     Top Result: {result.RetrievedFragments[0].Category}");
+        }
+    }
+
+    #endregion
+
+    #region Summary Reports
+
+    public static void ShowSummaryHeader(TestSummary summary)
+    {
+        Console.WriteLine("\n" + new string('=', 80));
+        Console.WriteLine("RAG QUALITY TEST SUMMARY");
+        Console.WriteLine(new string('=', 80));
+        Console.WriteLine($"Test Run: {summary.TestRunTime:yyyy-MM-dd HH:mm:ss}");
+        Console.WriteLine($"Total Execution Time: {summary.TotalExecutionTime.TotalSeconds:F2}s");
+        Console.WriteLine();
+    }
+
+    public static void ShowOverallResults(TestSummary summary)
+    {
+        Console.WriteLine("OVERALL RESULTS:");
+        Console.WriteLine($"  Total Tests: {summary.TotalTests}");
+        Console.WriteLine($"  Successful: {summary.SuccessfulTests} ({summary.SuccessRate:F1}%)");
+        Console.WriteLine($"  Failed: {summary.FailedTests}");
+        Console.WriteLine($"  Passed Threshold: {summary.PassedThreshold} ({summary.ThresholdPassRate:F1}%)");
+        Console.WriteLine();
+    }
+
+    public static void ShowQualityMetrics(TestSummary summary)
+    {
+        Console.WriteLine("QUALITY METRICS:");
+        Console.WriteLine($"  Average Relevance: {summary.AverageRelevanceAllTests:F3}");
+        Console.WriteLine($"  Average Keyword Match: {summary.AverageKeywordMatchRate:F1}%");
+        Console.WriteLine();
+    }
+
+    public static void ShowQualityDistribution(TestSummary summary, Func<string, int> getQualityScore)
+    {
+        Console.WriteLine("QUALITY DISTRIBUTION:");
+        foreach (var kvp in summary.QualityDistribution.OrderByDescending(x => getQualityScore(x.Key)))
+        {
+            var percentage = (double)kvp.Value / summary.SuccessfulTests * 100;
+            Console.WriteLine($"  {kvp.Key}: {kvp.Value} ({percentage:F1}%)");
+        }
+        Console.WriteLine();
+    }
+
+    public static void ShowTopPerformingQueries(IEnumerable<TestResult> topQueries)
+    {
+        Console.WriteLine("TOP PERFORMING QUERIES:");
+        foreach (var result in topQueries)
+        {
+            Console.WriteLine($"  ? {result.QueryId}: {result.MaxRelevance:F3} - {result.Query}");
+        }
+        Console.WriteLine();
+    }
+
+    public static void ShowQueriesNeedingImprovement(IEnumerable<TestResult> worstQueries)
+    {
+        Console.WriteLine("QUERIES NEEDING IMPROVEMENT:");
+        foreach (var result in worstQueries)
+        {
+            var icon = result.PassedMinimumThreshold ? "??" : "?";
+            Console.WriteLine($"  {icon} {result.QueryId}: {result.MaxRelevance:F3} - {result.Query}");
+        }
+        Console.WriteLine();
+    }
+
+    public static void ShowReportsSaved(string outputPath)
+    {
+        Console.WriteLine(new string('=', 80));
+        Console.WriteLine($"Reports saved to: {Path.GetFullPath(outputPath)}");
+        Console.WriteLine(new string('=', 80));
+    }
+
+    public static void ShowReportGenerated(string reportType, string filename)
+    {
+        Console.WriteLine($"?? {reportType} report: {filename}");
+    }
+
+    #endregion
+
+    #region Exit Messages
+
+    public static void ShowTestsFailedMessage()
+    {
+        Console.WriteLine("\n??  Some tests failed. Check the reports for details.");
+    }
+
+    public static void ShowLowPassRateMessage(double passRate)
+    {
+        Console.WriteLine($"\n??  Only {passRate:F1}% of tests passed their minimum threshold.");
+    }
+
+    public static void ShowAllTestsPassedMessage()
+    {
+        Console.WriteLine("\n? All tests passed!");
+    }
+
+    public static void ShowFatalError(Exception ex)
+    {
+        Console.WriteLine($"\n? Fatal error: {ex.Message}");
+        Console.WriteLine(ex.StackTrace);
+    }
+
+    #endregion
+
+    #region Utilities
+
+    public static void WriteLine(string message = "")
+    {
+        Console.WriteLine(message);
+    }
+
+    public static void Write(string message)
+    {
+        Console.Write(message);
+    }
+
+    #endregion
+}

--- a/Services/Configuration/AppConfiguration.cs
+++ b/Services/Configuration/AppConfiguration.cs
@@ -45,6 +45,32 @@ public class LlmSettings
     /// Example: "d:\tinyllama\tinyllama-1.1b-chat-v1.0.Q5_K_M.gguf"
     /// </summary>
     public string ModelPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Friendly model name for display purposes
+    /// Example: "mistral-7b-instruct-v0.2.Q5_K_M"
+    /// </summary>
+    public string? ModelName { get; set; }
+
+    /// <summary>
+    /// Optional model family/type label (e.g., "Mistral", "Llama3")
+    /// </summary>
+    public string? ModelType { get; set; }
+
+    /// <summary>
+    /// Optional hint whether to use GPU (parsed but not required by runtime logic)
+    /// </summary>
+    public bool UseGpu { get; set; } = false;
+
+    /// <summary>
+    /// Optional GPU layers hint for llama backends
+    /// </summary>
+    public int GpuLayers { get; set; } = 0;
+
+    /// <summary>
+    /// Optional context size hint for llama backends
+    /// </summary>
+    public int ContextSize { get; set; } = 0;
 }
 
 public class EmbeddingSettings

--- a/Services/Configuration/AppConfiguration.cs
+++ b/Services/Configuration/AppConfiguration.cs
@@ -107,6 +107,13 @@ public class DebugSettings
     public bool EnableDebugMode { get; set; } = false;
 
     /// <summary>
+    /// Enable RAG mode (uses semantic search with vector memory)
+    /// When false, directly talks to the LLM without context retrieval
+    /// Default: true (RAG enabled)
+    /// </summary>
+    public bool EnableRagMode { get; set; } = false;
+
+    /// <summary>
     /// Collection name for vector memory
     /// Default: "game-rules-mpnet"
     /// </summary>

--- a/Services/Configuration/AppConfiguration.cs
+++ b/Services/Configuration/AppConfiguration.cs
@@ -137,7 +137,7 @@ public class DebugSettings
     /// When false, directly talks to the LLM without context retrieval
     /// Default: true (RAG enabled)
     /// </summary>
-    public bool EnableRagMode { get; set; } = false;
+    public bool EnableRagMode { get; set; } = true;
 
     /// <summary>
     /// Collection name for vector memory

--- a/Services/UI/DisplayService.cs
+++ b/Services/UI/DisplayService.cs
@@ -204,6 +204,7 @@ public static class DisplayService
             Console.WriteLine("  /pool           - Show model pool status");
         }
         
+        Console.WriteLine("  /rag            - Toggle RAG mode (semantic search on/off)");
         Console.WriteLine("  /reload         - Check inbox for new files and process them");
         Console.WriteLine("  exit            - Quit");
     }


### PR DESCRIPTION
Adds the ability to disable RAG (Retrieval-Augmented Generation) mode, allowing for direct conversations with the LLM without knowledge base context.

- Introduces a new `enableRag` parameter to `AiChatServicePooled` to control RAG usage.
- Adds a `/rag` command to toggle RAG mode at runtime.
- Updates UI to display RAG mode status.