### PR TITLE
Add peer clustering (overflow forwarding) to AgentKit.Api

### DIFF
--- a/AgentKit.Api.Tests/Controllers/AgentJobsControllerTests.cs
+++ b/AgentKit.Api.Tests/Controllers/AgentJobsControllerTests.cs
@@ -9,39 +9,21 @@ using Moq;
 namespace AgentKit.Api.Tests.Controllers;
 
 /// <summary>
-/// Unit tests for <see cref="AgentJobsController"/>: request validation, status lookup
-/// (live-then-persisted fallback), result download gating by phase, and error mapping.
-/// The job service is mocked throughout — no real agent run or LLM call happens here.
+/// Unit tests for <see cref="AgentJobsController"/>: request validation, status lookup, result
+/// download gating by phase, and error mapping. The job service is mocked throughout — no real
+/// agent run, LLM call, or peer network call happens here. Zip-building itself (local vs. proxied
+/// from a peer) is <see cref="AgentJobService"/>'s responsibility and is tested there; this class
+/// only checks the controller passes whatever stream the service returns straight through.
 /// </summary>
-public sealed class AgentJobsControllerTests : IDisposable
+public class AgentJobsControllerTests
 {
     private readonly Mock<IAgentJobService> _mockJobService;
     private readonly AgentJobsController _controller;
-    private readonly List<string> _tempDirs = new();
 
     public AgentJobsControllerTests()
     {
         _mockJobService = new Mock<IAgentJobService>();
         _controller = new AgentJobsController(_mockJobService.Object, new Mock<ILogger<AgentJobsController>>().Object);
-    }
-
-    public void Dispose()
-    {
-        foreach (var dir in _tempDirs)
-        {
-            if (Directory.Exists(dir))
-                Directory.Delete(dir, recursive: true);
-        }
-    }
-
-    private string CreateTempWorkspace(params (string Name, string Content)[] files)
-    {
-        var dir = Path.Combine(Path.GetTempPath(), "AgentJobsControllerTests_" + Guid.NewGuid());
-        Directory.CreateDirectory(dir);
-        _tempDirs.Add(dir);
-        foreach (var (name, content) in files)
-            File.WriteAllText(Path.Combine(dir, name), content);
-        return dir;
     }
 
     private static AgentJobStatus MakeStatus(string phase, Guid? jobId = null) => new(
@@ -53,15 +35,30 @@ public sealed class AgentJobsControllerTests : IDisposable
         new List<AgentJobRequirementStatus>(),
         new List<string>());
 
+    private static MemoryStream MakeZipStream(string entryName = "recept.txt")
+    {
+        var buffer = new MemoryStream();
+        using (var zip = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry(entryName);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write("klart");
+        }
+        buffer.Position = 0;
+        return buffer;
+    }
+
     // ── StartJob ────────────────────────────────────────────────────────
 
     [Fact]
-    public void StartJob_ValidRequest_ReturnsAcceptedWithJobId()
+    public async Task StartJob_ValidRequest_ReturnsAcceptedWithJobId()
     {
         var jobId = Guid.NewGuid();
-        _mockJobService.Setup(s => s.StartJob("Skapa ett pannkaksrecept", null)).Returns(jobId);
+        _mockJobService
+            .Setup(s => s.StartJobAsync("Skapa ett pannkaksrecept", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jobId);
 
-        var result = _controller.StartJob(new StartJobRequest { GoalDescription = "Skapa ett pannkaksrecept" });
+        var result = await _controller.StartJob(new StartJobRequest { GoalDescription = "Skapa ett pannkaksrecept" }, CancellationToken.None);
 
         var accepted = Assert.IsType<AcceptedAtActionResult>(result.Result);
         var response = Assert.IsType<StartJobResponse>(accepted.Value);
@@ -69,66 +66,53 @@ public sealed class AgentJobsControllerTests : IDisposable
     }
 
     [Fact]
-    public void StartJob_PassesMaxIterationsThrough()
+    public async Task StartJob_PassesMaxIterationsThrough()
     {
-        _mockJobService.Setup(s => s.StartJob(It.IsAny<string>(), 5)).Returns(Guid.NewGuid());
+        _mockJobService
+            .Setup(s => s.StartJobAsync(It.IsAny<string>(), 5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
 
-        _controller.StartJob(new StartJobRequest { GoalDescription = "Mål", MaxIterations = 5 });
+        await _controller.StartJob(new StartJobRequest { GoalDescription = "Mål", MaxIterations = 5 }, CancellationToken.None);
 
-        _mockJobService.Verify(s => s.StartJob("Mål", 5), Times.Once);
+        _mockJobService.Verify(s => s.StartJobAsync("Mål", 5, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
     [InlineData(null)]
-    public void StartJob_EmptyGoalDescription_ReturnsBadRequest(string? goalDescription)
+    public async Task StartJob_EmptyGoalDescription_ReturnsBadRequest(string? goalDescription)
     {
-        var result = _controller.StartJob(new StartJobRequest { GoalDescription = goalDescription! });
+        var result = await _controller.StartJob(new StartJobRequest { GoalDescription = goalDescription! }, CancellationToken.None);
 
         var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
         var error = Assert.IsType<ErrorResponse>(badRequest.Value);
         Assert.Equal(400, error.StatusCode);
+        _mockJobService.Verify(s => s.StartJobAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── GetStatus ───────────────────────────────────────────────────────
 
     [Fact]
-    public async Task GetStatus_LiveJob_ReturnsLiveStatusWithoutTouchingPersistedFallback()
+    public async Task GetStatus_KnownJob_ReturnsOk()
     {
         var jobId = Guid.NewGuid();
         var status = MakeStatus("Working", jobId);
-        _mockJobService.Setup(s => s.GetStatus(jobId)).Returns(status);
+        _mockJobService.Setup(s => s.GetStatusAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(status);
 
-        var result = await _controller.GetStatus(jobId);
+        var result = await _controller.GetStatus(jobId, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Same(status, ok.Value);
-        _mockJobService.Verify(s => s.GetPersistedStatusAsync(It.IsAny<Guid>()), Times.Never);
     }
 
     [Fact]
-    public async Task GetStatus_NotLiveButPersisted_FallsBackToPersistedStatus()
+    public async Task GetStatus_UnknownJob_ReturnsNotFound()
     {
         var jobId = Guid.NewGuid();
-        var persisted = MakeStatus("Completed", jobId);
-        _mockJobService.Setup(s => s.GetStatus(jobId)).Returns((AgentJobStatus?)null);
-        _mockJobService.Setup(s => s.GetPersistedStatusAsync(jobId)).ReturnsAsync(persisted);
+        _mockJobService.Setup(s => s.GetStatusAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync((AgentJobStatus?)null);
 
-        var result = await _controller.GetStatus(jobId);
-
-        var ok = Assert.IsType<OkObjectResult>(result.Result);
-        Assert.Same(persisted, ok.Value);
-    }
-
-    [Fact]
-    public async Task GetStatus_UnknownEverywhere_ReturnsNotFound()
-    {
-        var jobId = Guid.NewGuid();
-        _mockJobService.Setup(s => s.GetStatus(jobId)).Returns((AgentJobStatus?)null);
-        _mockJobService.Setup(s => s.GetPersistedStatusAsync(jobId)).ReturnsAsync((AgentJobStatus?)null);
-
-        var result = await _controller.GetStatus(jobId);
+        var result = await _controller.GetStatus(jobId, CancellationToken.None);
 
         var notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
         Assert.Equal(404, Assert.IsType<ErrorResponse>(notFound.Value).StatusCode);
@@ -137,79 +121,76 @@ public sealed class AgentJobsControllerTests : IDisposable
     // ── GetResult ───────────────────────────────────────────────────────
 
     [Fact]
-    public void GetResult_UnknownJob_ReturnsNotFound()
+    public async Task GetResult_UnknownJob_ReturnsNotFound()
     {
         var jobId = Guid.NewGuid();
-        _mockJobService.Setup(s => s.GetStatus(jobId)).Returns((AgentJobStatus?)null);
+        _mockJobService.Setup(s => s.GetStatusAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync((AgentJobStatus?)null);
 
-        var result = _controller.GetResult(jobId);
+        var result = await _controller.GetResult(jobId, CancellationToken.None);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
 
     [Fact]
-    public void GetResult_StillRunning_ReturnsConflict()
+    public async Task GetResult_StillRunning_ReturnsConflict()
     {
         var jobId = Guid.NewGuid();
-        _mockJobService.Setup(s => s.GetStatus(jobId)).Returns(MakeStatus("Working", jobId));
+        _mockJobService.Setup(s => s.GetStatusAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(MakeStatus("Working", jobId));
 
-        var result = _controller.GetResult(jobId);
+        var result = await _controller.GetResult(jobId, CancellationToken.None);
 
         var conflict = Assert.IsType<ConflictObjectResult>(result);
         Assert.Equal(409, Assert.IsType<ErrorResponse>(conflict.Value).StatusCode);
+        _mockJobService.Verify(s => s.GetResultZipAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public void GetResult_TerminalPhaseButWorkspaceGone_ReturnsNotFound()
+    public async Task GetResult_TerminalPhaseButZipUnavailable_ReturnsNotFound()
     {
         var jobId = Guid.NewGuid();
-        _mockJobService.Setup(s => s.GetStatus(jobId)).Returns(MakeStatus("Completed", jobId));
-        _mockJobService.Setup(s => s.GetWorkspacePath(jobId)).Returns((string?)null);
+        _mockJobService.Setup(s => s.GetStatusAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(MakeStatus("Completed", jobId));
+        _mockJobService.Setup(s => s.GetResultZipAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync((Stream?)null);
 
-        var result = _controller.GetResult(jobId);
+        var result = await _controller.GetResult(jobId, CancellationToken.None);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
 
     [Fact]
-    public void GetResult_CompletedWithFiles_ReturnsZipContainingThem()
+    public async Task GetResult_TerminalPhaseWithZip_ReturnsItAsFileDownload()
     {
         var jobId = Guid.NewGuid();
-        var workspace = CreateTempWorkspace(("recept.txt", "Pannkaksrecept\n1. Vispa\n"), ("notes.txt", "klart"));
-        _mockJobService.Setup(s => s.GetStatus(jobId)).Returns(MakeStatus("Completed", jobId));
-        _mockJobService.Setup(s => s.GetWorkspacePath(jobId)).Returns(workspace);
+        var zip = MakeZipStream();
+        _mockJobService.Setup(s => s.GetStatusAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(MakeStatus("Completed", jobId));
+        _mockJobService.Setup(s => s.GetResultZipAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(zip);
 
-        var result = _controller.GetResult(jobId);
+        var result = await _controller.GetResult(jobId, CancellationToken.None);
 
         var fileResult = Assert.IsType<FileStreamResult>(result);
         Assert.Equal("application/zip", fileResult.ContentType);
-
-        using var zip = new ZipArchive(fileResult.FileStream, ZipArchiveMode.Read);
-        Assert.Equal(2, zip.Entries.Count);
-        Assert.Contains(zip.Entries, e => e.Name == "recept.txt");
-        Assert.Contains(zip.Entries, e => e.Name == "notes.txt");
+        Assert.Same(zip, fileResult.FileStream);
     }
 
     // ── StopJob ─────────────────────────────────────────────────────────
 
     [Fact]
-    public void StopJob_KnownJob_ReturnsOk()
+    public async Task StopJob_KnownJob_ReturnsOk()
     {
         var jobId = Guid.NewGuid();
-        _mockJobService.Setup(s => s.RequestStop(jobId)).Returns(true);
+        _mockJobService.Setup(s => s.RequestStopAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-        var result = _controller.StopJob(jobId);
+        var result = await _controller.StopJob(jobId, CancellationToken.None);
 
         Assert.IsType<OkResult>(result);
     }
 
     [Fact]
-    public void StopJob_UnknownJob_ReturnsNotFound()
+    public async Task StopJob_UnknownJob_ReturnsNotFound()
     {
         var jobId = Guid.NewGuid();
-        _mockJobService.Setup(s => s.RequestStop(jobId)).Returns(false);
+        _mockJobService.Setup(s => s.RequestStopAsync(jobId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
-        var result = _controller.StopJob(jobId);
+        var result = await _controller.StopJob(jobId, CancellationToken.None);
 
         Assert.IsType<NotFoundObjectResult>(result);
     }
@@ -223,9 +204,9 @@ public sealed class AgentJobsControllerTests : IDisposable
         {
             new(Guid.NewGuid(), "Mål 1", "Completed", 3, 20, DateTime.UtcNow, DateTime.UtcNow)
         };
-        _mockJobService.Setup(s => s.GetRecentJobsAsync(25)).ReturnsAsync(jobs);
+        _mockJobService.Setup(s => s.GetRecentJobsAsync(25, It.IsAny<CancellationToken>())).ReturnsAsync(jobs);
 
-        var result = await _controller.GetRecentJobs();
+        var result = await _controller.GetRecentJobs(cancellationToken: CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Same(jobs, ok.Value);

--- a/AgentKit.Api.Tests/Services/AgentJobServiceTests.cs
+++ b/AgentKit.Api.Tests/Services/AgentJobServiceTests.cs
@@ -1,3 +1,4 @@
+using AgentKit.Api.Models;
 using AgentKit.Api.Services;
 using Application.AI.Pooling;
 using Entities;
@@ -9,94 +10,198 @@ using Services.Repositories;
 namespace AgentKit.Api.Tests.Services;
 
 /// <summary>
-/// Unit tests for <see cref="AgentJobService"/>. Deliberately does NOT exercise
-/// <see cref="AgentJobService.StartJob"/>'s success path: that kicks off a real background run
-/// against the real <see cref="IModelInstancePool"/>/LLM backend, which must not happen in
-/// automated tests (see CLAUDE.md / project constraint: no real LLM calls). The goal-agent loop
-/// itself is already covered by <c>Services.Tests/GoalAgent/GoalAgentServiceTests.cs</c> with a
-/// fake LLM delegate — this class only tests the job-service plumbing around it: unknown-job
-/// handling, and the DB-backed status/summary mapping, none of which touch the LLM.
+/// Unit tests for <see cref="AgentJobService"/>. Deliberately does NOT exercise a job's actual
+/// execution: that kicks off a real background run against the real <see cref="IModelInstancePool"/>
+/// /LLM backend, which must not happen in automated tests (see CLAUDE.md / project constraint: no
+/// real LLM calls). The goal-agent loop itself is already covered by
+/// <c>Services.Tests/GoalAgent/GoalAgentServiceTests.cs</c> with a fake LLM delegate. This class
+/// covers everything AROUND that: unknown-job handling, DB-backed status/summary mapping, the
+/// local-vs-forward-to-peer routing decision (via a mocked <see cref="IClusterPeerClient"/>, so no
+/// real network call happens either), and proxying for a job tracked as remote.
 /// </summary>
-public class AgentJobServiceTests
+public sealed class AgentJobServiceTests : IDisposable
 {
     private readonly Mock<IModelInstancePool> _mockPool = new();
+    private readonly Mock<IClusterPeerClient> _mockPeerClient = new();
     private readonly AppConfiguration _appConfig = new();
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
 
     private AgentJobService CreateSut(IAgentRunRepository? repository = null) =>
-        new(_mockPool.Object, _appConfig, new Mock<ILogger<AgentJobService>>().Object, repository);
+        new(_mockPool.Object, _appConfig, _mockPeerClient.Object, new Mock<ILogger<AgentJobService>>().Object, repository);
+
+    private static ClusterPeerSettings MakePeer(string name) => new() { Name = name, BaseUrl = $"https://{name}:7016", ApiKey = "key" };
 
     // ── Constructor ─────────────────────────────────────────────────────
 
     [Fact]
     public void Constructor_NullModelPool_ThrowsArgumentNullException()
     {
-        var act = () => new AgentJobService(null!, _appConfig, new Mock<ILogger<AgentJobService>>().Object);
+        var act = () => new AgentJobService(null!, _appConfig, _mockPeerClient.Object, new Mock<ILogger<AgentJobService>>().Object);
         Assert.Throws<ArgumentNullException>(act);
     }
 
     [Fact]
     public void Constructor_NullAppConfig_ThrowsArgumentNullException()
     {
-        var act = () => new AgentJobService(_mockPool.Object, null!, new Mock<ILogger<AgentJobService>>().Object);
+        var act = () => new AgentJobService(_mockPool.Object, null!, _mockPeerClient.Object, new Mock<ILogger<AgentJobService>>().Object);
         Assert.Throws<ArgumentNullException>(act);
     }
 
-    // ── StartJob input validation (fires before anything touches the LLM) ──
+    [Fact]
+    public void Constructor_NullClusterPeerClient_ThrowsArgumentNullException()
+    {
+        var act = () => new AgentJobService(_mockPool.Object, _appConfig, null!, new Mock<ILogger<AgentJobService>>().Object);
+        Assert.Throws<ArgumentNullException>(act);
+    }
+
+    // ── StartJobAsync input validation (fires before anything touches the LLM or a peer) ──
 
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void StartJob_EmptyGoalDescription_ThrowsWithoutStartingAnything(string goalDescription)
+    public async Task StartJobAsync_EmptyGoalDescription_ThrowsWithoutStartingAnything(string goalDescription)
     {
         var sut = CreateSut();
-        Action act = () => sut.StartJob(goalDescription, null);
-        Assert.Throws<ArgumentException>(act);
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.StartJobAsync(goalDescription, null, CancellationToken.None));
+        _mockPeerClient.Verify(c => c.GetAvailableCapacityAsync(It.IsAny<ClusterPeerSettings>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
-    // ── Unknown-job behavior (no job was ever started, so this never touches the LLM) ──
+    // ── StartJobAsync routing decision ──────────────────────────────────
 
     [Fact]
-    public void GetStatus_UnknownJob_ReturnsNull()
+    public async Task StartJobAsync_NoPeersConfigured_NeverTouchesPeerClient()
     {
+        _mockPool.Setup(p => p.AvailableCount).Returns(0);
         var sut = CreateSut();
-        Assert.Null(sut.GetStatus(Guid.NewGuid()));
-    }
 
-    [Fact]
-    public void GetWorkspacePath_UnknownJob_ReturnsNull()
-    {
-        var sut = CreateSut();
-        Assert.Null(sut.GetWorkspacePath(Guid.NewGuid()));
+        await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        _mockPeerClient.Verify(c => c.GetAvailableCapacityAsync(It.IsAny<ClusterPeerSettings>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockPeerClient.Verify(c => c.ForwardJobAsync(It.IsAny<ClusterPeerSettings>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public void RequestStop_UnknownJob_ReturnsFalse()
+    public async Task StartJobAsync_LocalHasRoom_NeverChecksPeersEvenIfConfigured()
     {
+        _appConfig.Cluster.Peers.Add(MakePeer("peer1"));
+        _mockPool.Setup(p => p.AvailableCount).Returns(2);
         var sut = CreateSut();
-        Assert.False(sut.RequestStop(Guid.NewGuid()));
+
+        await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        _mockPeerClient.Verify(c => c.GetAvailableCapacityAsync(It.IsAny<ClusterPeerSettings>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
-    // ── No repository configured ─────────────────────────────────────────
+    [Fact]
+    public async Task StartJobAsync_LocalSaturatedAndPeerHasCapacity_ForwardsToThatPeer()
+    {
+        var peer = MakePeer("peer1");
+        _appConfig.Cluster.Peers.Add(peer);
+        _mockPool.Setup(p => p.AvailableCount).Returns(0);
+        _mockPeerClient.Setup(c => c.GetAvailableCapacityAsync(peer, It.IsAny<CancellationToken>())).ReturnsAsync(3);
+        var forwardedPeerJobId = Guid.NewGuid();
+        _mockPeerClient
+            .Setup(c => c.ForwardJobAsync(peer, "Mål", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(forwardedPeerJobId);
+        var sut = CreateSut();
+
+        var jobId = await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        _mockPeerClient.Verify(c => c.ForwardJobAsync(peer, "Mål", null, It.IsAny<CancellationToken>()), Times.Once);
+
+        // The job is now tracked as remote — GetStatusAsync must proxy to that same peer/id.
+        var remoteStatus = new AgentJobStatus(forwardedPeerJobId, "Working", "Mål", 1, 20, new List<AgentJobRequirementStatus>(), new List<string>());
+        _mockPeerClient.Setup(c => c.GetRemoteStatusAsync(peer, forwardedPeerJobId, It.IsAny<CancellationToken>())).ReturnsAsync(remoteStatus);
+
+        var status = await sut.GetStatusAsync(jobId, CancellationToken.None);
+        Assert.Same(remoteStatus, status);
+    }
 
     [Fact]
-    public async Task GetPersistedStatusAsync_NoRepositoryConfigured_ReturnsNull()
+    public async Task StartJobAsync_FirstPeerHasNoCapacity_TriesSecondPeer()
     {
-        var sut = CreateSut(repository: null);
-        Assert.Null(await sut.GetPersistedStatusAsync(Guid.NewGuid()));
+        var peer1 = MakePeer("peer1");
+        var peer2 = MakePeer("peer2");
+        _appConfig.Cluster.Peers.Add(peer1);
+        _appConfig.Cluster.Peers.Add(peer2);
+        _mockPool.Setup(p => p.AvailableCount).Returns(0);
+        _mockPeerClient.Setup(c => c.GetAvailableCapacityAsync(peer1, It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        _mockPeerClient.Setup(c => c.GetAvailableCapacityAsync(peer2, It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        _mockPeerClient
+            .Setup(c => c.ForwardJobAsync(peer2, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        var sut = CreateSut();
+
+        await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        _mockPeerClient.Verify(c => c.ForwardJobAsync(peer1, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockPeerClient.Verify(c => c.ForwardJobAsync(peer2, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartJobAsync_EveryPeerUnreachableOrFull_FallsBackToLocalWithoutThrowing()
+    {
+        var peer1 = MakePeer("peer1");
+        var peer2 = MakePeer("peer2");
+        _appConfig.Cluster.Peers.Add(peer1);
+        _appConfig.Cluster.Peers.Add(peer2);
+        _mockPool.Setup(p => p.AvailableCount).Returns(0);
+        _mockPeerClient.Setup(c => c.GetAvailableCapacityAsync(peer1, It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        _mockPeerClient.Setup(c => c.GetAvailableCapacityAsync(peer2, It.IsAny<CancellationToken>())).ReturnsAsync((int?)null); // unreachable
+        var sut = CreateSut();
+
+        // Must complete without throwing and without ever forwarding — falls back to a local
+        // (queued) run, exactly like Phase 1's only behavior.
+        var jobId = await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, jobId);
+        _mockPeerClient.Verify(c => c.ForwardJobAsync(It.IsAny<ClusterPeerSettings>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Unknown-job behavior (no job was ever started, so this never touches the LLM or a peer) ──
+
+    [Fact]
+    public async Task GetStatusAsync_UnknownJobAndNoRepository_ReturnsNull()
+    {
+        var sut = CreateSut();
+        Assert.Null(await sut.GetStatusAsync(Guid.NewGuid(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetResultZipAsync_UnknownJob_ReturnsNull()
+    {
+        var sut = CreateSut();
+        Assert.Null(await sut.GetResultZipAsync(Guid.NewGuid(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RequestStopAsync_UnknownJob_ReturnsFalse()
+    {
+        var sut = CreateSut();
+        Assert.False(await sut.RequestStopAsync(Guid.NewGuid(), CancellationToken.None));
     }
 
     [Fact]
     public async Task GetRecentJobsAsync_NoRepositoryConfigured_ReturnsEmpty()
     {
         var sut = CreateSut(repository: null);
-        var jobs = await sut.GetRecentJobsAsync(25);
+        var jobs = await sut.GetRecentJobsAsync(25, CancellationToken.None);
         Assert.Empty(jobs);
     }
 
-    // ── Persisted status / recent-jobs mapping (fake repository, no LLM involved) ──
+    // ── Persisted status / recent-jobs mapping (fake repository, no LLM or peer involved) ──
 
     [Fact]
-    public async Task GetPersistedStatusAsync_ExistingRun_MapsEntityFieldsToStatus()
+    public async Task GetStatusAsync_UnknownToProcessButPersisted_FallsBackToDatabase()
     {
         var runId = Guid.NewGuid();
         var repository = new FakeAgentRunRepository();
@@ -120,7 +225,7 @@ public class AgentJobServiceTests
         };
         var sut = CreateSut(repository);
 
-        var status = await sut.GetPersistedStatusAsync(runId);
+        var status = await sut.GetStatusAsync(runId, CancellationToken.None);
 
         Assert.NotNull(status);
         Assert.Equal("Skapa ett pannkaksrecept", status!.GoalDescription);
@@ -131,13 +236,6 @@ public class AgentJobServiceTests
         Assert.Equal(new[] { "krav A", "krav B" }, status.Requirements.Select(r => r.Description));
         Assert.Equal("saknas", status.Requirements[0].LastVerdict);
         Assert.Equal(new[] { "först", "sedan" }, status.ActivityLog);
-    }
-
-    [Fact]
-    public async Task GetPersistedStatusAsync_UnknownRun_ReturnsNull()
-    {
-        var sut = CreateSut(new FakeAgentRunRepository());
-        Assert.Null(await sut.GetPersistedStatusAsync(Guid.NewGuid()));
     }
 
     [Fact]
@@ -157,7 +255,7 @@ public class AgentJobServiceTests
         };
         var sut = CreateSut(repository);
 
-        var summaries = await sut.GetRecentJobsAsync(25);
+        var summaries = await sut.GetRecentJobsAsync(25, CancellationToken.None);
 
         var summary = Assert.Single(summaries);
         Assert.Equal(runId, summary.JobId);
@@ -165,6 +263,74 @@ public class AgentJobServiceTests
         Assert.Equal("Completed", summary.Phase);
         Assert.Equal(2, summary.Iterations);
         Assert.Equal(20, summary.MaxIterations);
+    }
+
+    // ── Remote job proxying (job tracked here as forwarded to a peer) ──
+
+    [Fact]
+    public async Task GetResultZipAsync_RemoteJob_ProxiesToThePeerItWasForwardedTo()
+    {
+        var peer = MakePeer("peer1");
+        _appConfig.Cluster.Peers.Add(peer);
+        _mockPool.Setup(p => p.AvailableCount).Returns(0);
+        _mockPeerClient.Setup(c => c.GetAvailableCapacityAsync(peer, It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        var peerJobId = Guid.NewGuid();
+        _mockPeerClient.Setup(c => c.ForwardJobAsync(peer, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>())).ReturnsAsync(peerJobId);
+        var sut = CreateSut();
+        var jobId = await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        using var expectedZip = new MemoryStream();
+        _mockPeerClient.Setup(c => c.GetRemoteResultZipAsync(peer, peerJobId, It.IsAny<CancellationToken>())).ReturnsAsync(expectedZip);
+
+        var zip = await sut.GetResultZipAsync(jobId, CancellationToken.None);
+
+        Assert.Same(expectedZip, zip);
+    }
+
+    [Fact]
+    public async Task RequestStopAsync_RemoteJob_ProxiesToThePeerItWasForwardedTo()
+    {
+        var peer = MakePeer("peer1");
+        _appConfig.Cluster.Peers.Add(peer);
+        _mockPool.Setup(p => p.AvailableCount).Returns(0);
+        _mockPeerClient.Setup(c => c.GetAvailableCapacityAsync(peer, It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        var peerJobId = Guid.NewGuid();
+        _mockPeerClient.Setup(c => c.ForwardJobAsync(peer, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>())).ReturnsAsync(peerJobId);
+        var sut = CreateSut();
+        var jobId = await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        _mockPeerClient.Setup(c => c.RequestRemoteStopAsync(peer, peerJobId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var stopped = await sut.RequestStopAsync(jobId, CancellationToken.None);
+
+        Assert.True(stopped);
+        _mockPeerClient.Verify(c => c.RequestRemoteStopAsync(peer, peerJobId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── Local job result zip (file I/O only — no LLM/peer involved) ──
+
+    [Fact]
+    public async Task GetResultZipAsync_LocalJobWithFiles_ReturnsZipContainingThem()
+    {
+        var jobsRoot = Path.Combine(Path.GetTempPath(), "AgentJobServiceTests_" + Guid.NewGuid());
+        _tempDirs.Add(jobsRoot);
+        _appConfig.Jobs.RootFolder = jobsRoot;
+        // Local path is taken because no peers are configured, regardless of pool capacity.
+        var sut = CreateSut();
+
+        var jobId = await sut.StartJobAsync("Mål", null, CancellationToken.None);
+
+        // StartJobAsync already created the job's workspace directory via FileAgentService's
+        // constructor; write a file into it directly rather than waiting on the (mocked-pool,
+        // LLM-touching) background run to produce one.
+        var workspaceDir = Path.Combine(jobsRoot, jobId.ToString());
+        await File.WriteAllTextAsync(Path.Combine(workspaceDir, "recept.txt"), "Pannkaksrecept");
+
+        using var zip = await sut.GetResultZipAsync(jobId, CancellationToken.None);
+
+        Assert.NotNull(zip);
+        using var archive = new System.IO.Compression.ZipArchive(zip!, System.IO.Compression.ZipArchiveMode.Read);
+        Assert.Contains(archive.Entries, e => e.Name == "recept.txt");
     }
 
     private sealed class FakeAgentRunRepository : IAgentRunRepository

--- a/AgentKit.Api/Controllers/AgentJobsController.cs
+++ b/AgentKit.Api/Controllers/AgentJobsController.cs
@@ -1,4 +1,3 @@
-using System.IO.Compression;
 using AgentKit.Api.Models;
 using AgentKit.Api.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -9,7 +8,9 @@ namespace AgentKit.Api.Controllers;
 /// Headless goal-agent jobs: describe a desired workspace end result, poll progress, and download
 /// the resulting files once the job finishes. Mirrors what Agent Mode does in the dashboard, but
 /// as a start/poll/download HTTP flow instead of a live Blazor page, since a job can run for
-/// minutes and involves many LLM round trips — not a fit for a single blocking request.
+/// minutes and involves many LLM round trips — not a fit for a single blocking request. A job may
+/// run on this node or, when it's too busy, on a configured peer — the caller never needs to know
+/// which; every action here is keyed by the id returned from <see cref="StartJob"/>.
 /// </summary>
 [ApiController]
 [Route("api/jobs")]
@@ -34,7 +35,7 @@ public class AgentJobsController : ControllerBase
     [HttpPost]
     [ProducesResponseType(typeof(StartJobResponse), StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-    public ActionResult<StartJobResponse> StartJob([FromBody] StartJobRequest request)
+    public async Task<ActionResult<StartJobResponse>> StartJob([FromBody] StartJobRequest request, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(request.GoalDescription))
         {
@@ -45,23 +46,23 @@ public class AgentJobsController : ControllerBase
             });
         }
 
-        var jobId = _jobService.StartJob(request.GoalDescription.Trim(), request.MaxIterations);
+        var jobId = await _jobService.StartJobAsync(request.GoalDescription.Trim(), request.MaxIterations, cancellationToken);
         _logger.LogInformation("Started agent job {JobId}", jobId);
 
         return AcceptedAtAction(nameof(GetStatus), new { id = jobId }, new StartJobResponse(jobId));
     }
 
     /// <summary>
-    /// Job status: phase, iteration progress, requirements, and activity log. Served from process
-    /// memory while the job is live; falls back to persisted history for a job whose process
-    /// restarted (or that ran in an earlier process).
+    /// Job status: phase, iteration progress, requirements, and activity log. Served live
+    /// (locally or proxied from the peer running it) while the job is active; falls back to
+    /// persisted history for a job whose process restarted.
     /// </summary>
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(AgentJobStatus), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<AgentJobStatus>> GetStatus(Guid id)
+    public async Task<ActionResult<AgentJobStatus>> GetStatus(Guid id, CancellationToken cancellationToken)
     {
-        var status = _jobService.GetStatus(id) ?? await _jobService.GetPersistedStatusAsync(id);
+        var status = await _jobService.GetStatusAsync(id, cancellationToken);
         if (status is null)
         {
             return NotFound(new ErrorResponse
@@ -82,14 +83,14 @@ public class AgentJobsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status409Conflict)]
-    public ActionResult GetResult(Guid id)
+    public async Task<ActionResult> GetResult(Guid id, CancellationToken cancellationToken)
     {
-        var status = _jobService.GetStatus(id);
+        var status = await _jobService.GetStatusAsync(id, cancellationToken);
         if (status is null)
         {
             return NotFound(new ErrorResponse
             {
-                Error = $"Job {id} not found or not running in this process. If the server restarted mid-run, its files are still on disk but not downloadable through this endpoint yet.",
+                Error = $"Job {id} not found.",
                 StatusCode = StatusCodes.Status404NotFound
             });
         }
@@ -103,40 +104,26 @@ public class AgentJobsController : ControllerBase
             });
         }
 
-        var workspacePath = _jobService.GetWorkspacePath(id);
-        if (workspacePath is null || !Directory.Exists(workspacePath))
+        var zip = await _jobService.GetResultZipAsync(id, cancellationToken);
+        if (zip is null)
         {
             return NotFound(new ErrorResponse
             {
-                Error = $"Job {id}'s workspace directory is missing.",
+                Error = $"Job {id}'s result is unavailable (its workspace is missing, or the peer that ran it is unreachable).",
                 StatusCode = StatusCodes.Status404NotFound
             });
         }
 
-        // Built in memory rather than to a temp file — jobs are expected to produce at most a
-        // handful of MB of text/code, well within what's reasonable to hold in memory for the
-        // length of one response.
-        var buffer = new MemoryStream();
-        using (var zip = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
-        {
-            foreach (var file in Directory.GetFiles(workspacePath, "*", SearchOption.AllDirectories))
-            {
-                var entryName = Path.GetRelativePath(workspacePath, file);
-                zip.CreateEntryFromFile(file, entryName);
-            }
-        }
-        buffer.Position = 0;
-
-        return File(buffer, "application/zip", $"{id}.zip");
+        return File(zip, "application/zip", $"{id}.zip");
     }
 
     /// <summary>Requests the job stop at its next step boundary. No-ops (returns 404) for a job unknown to this process.</summary>
     [HttpPost("{id:guid}/stop")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
-    public ActionResult StopJob(Guid id)
+    public async Task<ActionResult> StopJob(Guid id, CancellationToken cancellationToken)
     {
-        if (!_jobService.RequestStop(id))
+        if (!await _jobService.RequestStopAsync(id, cancellationToken))
         {
             return NotFound(new ErrorResponse
             {
@@ -148,12 +135,12 @@ public class AgentJobsController : ControllerBase
         return Ok();
     }
 
-    /// <summary>Recent jobs (persisted history), newest first.</summary>
+    /// <summary>Recent jobs (this node's own persisted history), newest first.</summary>
     [HttpGet]
     [ProducesResponseType(typeof(List<AgentJobSummary>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IReadOnlyList<AgentJobSummary>>> GetRecentJobs([FromQuery] int count = 25)
+    public async Task<ActionResult<IReadOnlyList<AgentJobSummary>>> GetRecentJobs([FromQuery] int count = 25, CancellationToken cancellationToken = default)
     {
-        var jobs = await _jobService.GetRecentJobsAsync(count);
+        var jobs = await _jobService.GetRecentJobsAsync(count, cancellationToken);
         return Ok(jobs);
     }
 }

--- a/AgentKit.Api/Controllers/ClusterController.cs
+++ b/AgentKit.Api/Controllers/ClusterController.cs
@@ -1,0 +1,29 @@
+using AgentKit.Api.Models;
+using Application.AI.Pooling;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgentKit.Api.Controllers;
+
+/// <summary>
+/// Lets a peer node ask this one how busy it is before forwarding a job here. Goes through the
+/// normal <c>ApiKeyMiddleware</c> gate like any other endpoint — a peer authenticates with this
+/// node's configured API key, same as any other caller.
+/// </summary>
+[ApiController]
+[Route("api/cluster")]
+[Produces("application/json")]
+public class ClusterController : ControllerBase
+{
+    private readonly IModelInstancePool _modelPool;
+
+    public ClusterController(IModelInstancePool modelPool)
+    {
+        _modelPool = modelPool;
+    }
+
+    /// <summary>Current local LLM pool capacity — the signal peers use to decide whether to forward a job here.</summary>
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(ClusterStatus), StatusCodes.Status200OK)]
+    public ActionResult<ClusterStatus> GetStatus() =>
+        Ok(new ClusterStatus(_modelPool.AvailableCount, _modelPool.MaxInstances));
+}

--- a/AgentKit.Api/Models/ClusterModels.cs
+++ b/AgentKit.Api/Models/ClusterModels.cs
@@ -1,0 +1,6 @@
+namespace AgentKit.Api.Models;
+
+/// <summary>
+/// This node's current capacity, as reported to a peer deciding whether to forward a job here.
+/// </summary>
+public sealed record ClusterStatus(int AvailableCapacity, int MaxCapacity);

--- a/AgentKit.Api/Program.cs
+++ b/AgentKit.Api/Program.cs
@@ -116,6 +116,15 @@ else
     Console.WriteLine("[!] Database not configured (AppConfiguration:Database:ConnectionString missing) — job history and restart-safe status disabled.");
 }
 
+// ── Peer clustering: forward a job to another AgentKit.Api instance when this node is too busy
+//    and a peer (AppConfiguration.Cluster.Peers) has room. A short timeout keeps a dead/slow
+//    peer from stalling job submission. ──
+builder.Services.AddHttpClient(ClusterPeerClient.HttpClientName, client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(5);
+});
+builder.Services.AddSingleton<IClusterPeerClient, ClusterPeerClient>();
+
 builder.Services.AddSingleton<IAgentJobService, AgentJobService>();
 
 // Configure CORS from an explicit allow-list — see OfflineAI.Api/Program.cs for the same

--- a/AgentKit.Api/Services/AgentJobService.cs
+++ b/AgentKit.Api/Services/AgentJobService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.IO.Compression;
 using AgentKit.Api.Models;
 using AgentKit.Skills.External;
 using AgentKit.Skills.Files;
@@ -16,13 +17,22 @@ namespace AgentKit.Api.Services;
 /// <inheritdoc/>
 public sealed class AgentJobService : IAgentJobService
 {
-    /// <summary>Tracks a live job: the running agent plus the workspace directory it owns.</summary>
-    private sealed record JobEntry(GoalAgentService Agent, string WorkspacePath);
+    /// <summary>Marks a job tracked by this process: either running here, or forwarded to a peer.</summary>
+    private interface IJobEntry
+    {
+    }
 
-    private readonly ConcurrentDictionary<Guid, JobEntry> _jobs = new();
+    /// <summary>A job running locally: the agent plus the workspace directory it owns.</summary>
+    private sealed record LocalJobEntry(GoalAgentService Agent, string WorkspacePath) : IJobEntry;
+
+    /// <summary>A job forwarded to a peer node — proxied through <see cref="IClusterPeerClient"/> for everything.</summary>
+    private sealed record RemoteJobEntry(ClusterPeerSettings Peer, Guid PeerJobId) : IJobEntry;
+
+    private readonly ConcurrentDictionary<Guid, IJobEntry> _jobs = new();
 
     private readonly IModelInstancePool _modelPool;
     private readonly AppConfiguration _appConfig;
+    private readonly IClusterPeerClient _clusterPeerClient;
     private readonly IAgentRunRepository? _runRepository;
     private readonly IUtilityToolsService? _utilityTools;
     private readonly IExternalToolsService? _externalTools;
@@ -32,6 +42,7 @@ public sealed class AgentJobService : IAgentJobService
     public AgentJobService(
         IModelInstancePool modelPool,
         AppConfiguration appConfig,
+        IClusterPeerClient clusterPeerClient,
         ILogger<AgentJobService> logger,
         IAgentRunRepository? runRepository = null,
         IUtilityToolsService? utilityTools = null,
@@ -39,6 +50,7 @@ public sealed class AgentJobService : IAgentJobService
     {
         _modelPool = modelPool ?? throw new ArgumentNullException(nameof(modelPool));
         _appConfig = appConfig ?? throw new ArgumentNullException(nameof(appConfig));
+        _clusterPeerClient = clusterPeerClient ?? throw new ArgumentNullException(nameof(clusterPeerClient));
         _logger = logger;
         _runRepository = runRepository;
         _utilityTools = utilityTools;
@@ -52,10 +64,43 @@ public sealed class AgentJobService : IAgentJobService
     }
 
     /// <inheritdoc/>
-    public Guid StartJob(string goalDescription, int? maxIterations)
+    public async Task<Guid> StartJobAsync(string goalDescription, int? maxIterations, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(goalDescription);
 
+        var peers = _appConfig.Cluster.Peers;
+
+        // Skip every cluster check entirely when there's nothing to forward to, or when this
+        // node still has room — a single-node deployment (no peers configured) pays zero
+        // overhead beyond this one property read.
+        if (peers.Count > 0 && _modelPool.AvailableCount == 0)
+        {
+            foreach (var peer in peers)
+            {
+                var capacity = await _clusterPeerClient.GetAvailableCapacityAsync(peer, cancellationToken);
+                if (capacity is null or <= 0)
+                    continue;
+
+                var peerJobId = await _clusterPeerClient.ForwardJobAsync(peer, goalDescription, maxIterations, cancellationToken);
+                if (peerJobId is null)
+                    continue;
+
+                var forwardedJobId = Guid.NewGuid();
+                _jobs[forwardedJobId] = new RemoteJobEntry(peer, peerJobId.Value);
+                _logger.LogInformation(
+                    "Forwarded job {JobId} to peer {Peer} (peer's own id {PeerJobId})",
+                    forwardedJobId, peer.Name, peerJobId);
+                return forwardedJobId;
+            }
+
+            _logger.LogInformation("Local capacity saturated and no peer had room — running job locally, queued behind the local pool.");
+        }
+
+        return StartLocalJob(goalDescription, maxIterations);
+    }
+
+    private Guid StartLocalJob(string goalDescription, int? maxIterations)
+    {
         var jobId = Guid.NewGuid();
         var workspacePath = Path.Combine(_jobsRootFolder, jobId.ToString());
 
@@ -76,7 +121,7 @@ public sealed class AgentJobService : IAgentJobService
             maxIterations ?? _appConfig.AgentTools.MaxGoalIterations,
             _runRepository);
 
-        _jobs[jobId] = new JobEntry(goalAgent, workspacePath);
+        _jobs[jobId] = new LocalJobEntry(goalAgent, workspacePath);
 
         // Fire-and-forget from this singleton (not from the controller) so the run outlives the
         // HTTP request that started it — same pattern the dashboard uses from a button click.
@@ -126,26 +171,39 @@ public sealed class AgentJobService : IAgentJobService
     }
 
     /// <inheritdoc/>
-    public AgentJobStatus? GetStatus(Guid jobId)
+    public async Task<AgentJobStatus?> GetStatusAsync(Guid jobId, CancellationToken cancellationToken)
     {
-        if (!_jobs.TryGetValue(jobId, out var entry))
-            return null;
+        if (_jobs.TryGetValue(jobId, out var entry))
+        {
+            return entry switch
+            {
+                LocalJobEntry local => BuildLocalStatus(jobId, local.Agent),
+                RemoteJobEntry remote => await _clusterPeerClient.GetRemoteStatusAsync(remote.Peer, remote.PeerJobId, cancellationToken),
+                _ => null
+            };
+        }
 
-        var agent = entry.Agent;
-        return new AgentJobStatus(
-            jobId,
-            agent.Phase.ToString(),
-            agent.GoalDescription ?? string.Empty,
-            agent.CurrentIteration,
-            agent.MaxIterations,
-            agent.Requirements
-                .Select(r => new AgentJobRequirementStatus(r.Description, r.Status.ToString(), r.LastVerdict))
-                .ToList(),
-            agent.ActivityLog.ToList());
+        // Not tracked in this process — either an unknown id, or a locally-run job whose
+        // in-memory state was lost (e.g. this process restarted). Falls back to this node's own
+        // persisted history, which works for a job that ran HERE (same runId bridges the two —
+        // see GoalAgentService.RunAsync's runId parameter). A job this node had FORWARDED to a
+        // peer before restarting can't be recovered this way: the forwarding relationship itself
+        // only ever existed in memory. Accepted Phase 2 limitation, not solved here.
+        return await GetPersistedStatusAsync(jobId);
     }
 
-    /// <inheritdoc/>
-    public async Task<AgentJobStatus?> GetPersistedStatusAsync(Guid jobId)
+    private static AgentJobStatus BuildLocalStatus(Guid jobId, GoalAgentService agent) => new(
+        jobId,
+        agent.Phase.ToString(),
+        agent.GoalDescription ?? string.Empty,
+        agent.CurrentIteration,
+        agent.MaxIterations,
+        agent.Requirements
+            .Select(r => new AgentJobRequirementStatus(r.Description, r.Status.ToString(), r.LastVerdict))
+            .ToList(),
+        agent.ActivityLog.ToList());
+
+    private async Task<AgentJobStatus?> GetPersistedStatusAsync(Guid jobId)
     {
         if (_runRepository is null)
             return null;
@@ -171,21 +229,62 @@ public sealed class AgentJobService : IAgentJobService
     }
 
     /// <inheritdoc/>
-    public string? GetWorkspacePath(Guid jobId) =>
-        _jobs.TryGetValue(jobId, out var entry) ? entry.WorkspacePath : null;
+    public async Task<Stream?> GetResultZipAsync(Guid jobId, CancellationToken cancellationToken)
+    {
+        if (!_jobs.TryGetValue(jobId, out var entry))
+            return null;
+
+        return entry switch
+        {
+            LocalJobEntry local => BuildLocalResultZip(local.WorkspacePath),
+            RemoteJobEntry remote => await _clusterPeerClient.GetRemoteResultZipAsync(remote.Peer, remote.PeerJobId, cancellationToken),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Built in memory rather than to a temp file — jobs are expected to produce at most a
+    /// handful of MB of text/code, well within what's reasonable to hold in memory for the
+    /// length of one response.
+    /// </summary>
+    private static Stream? BuildLocalResultZip(string workspacePath)
+    {
+        if (!Directory.Exists(workspacePath))
+            return null;
+
+        var buffer = new MemoryStream();
+        using (var zip = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var file in Directory.GetFiles(workspacePath, "*", SearchOption.AllDirectories))
+            {
+                var entryName = Path.GetRelativePath(workspacePath, file);
+                zip.CreateEntryFromFile(file, entryName);
+            }
+        }
+        buffer.Position = 0;
+        return buffer;
+    }
 
     /// <inheritdoc/>
-    public bool RequestStop(Guid jobId)
+    public async Task<bool> RequestStopAsync(Guid jobId, CancellationToken cancellationToken)
     {
         if (!_jobs.TryGetValue(jobId, out var entry))
             return false;
 
-        entry.Agent.RequestStop();
-        return true;
+        switch (entry)
+        {
+            case LocalJobEntry local:
+                local.Agent.RequestStop();
+                return true;
+            case RemoteJobEntry remote:
+                return await _clusterPeerClient.RequestRemoteStopAsync(remote.Peer, remote.PeerJobId, cancellationToken);
+            default:
+                return false;
+        }
     }
 
     /// <inheritdoc/>
-    public async Task<IReadOnlyList<AgentJobSummary>> GetRecentJobsAsync(int count)
+    public async Task<IReadOnlyList<AgentJobSummary>> GetRecentJobsAsync(int count, CancellationToken cancellationToken)
     {
         if (_runRepository is null)
             return Array.Empty<AgentJobSummary>();

--- a/AgentKit.Api/Services/ClusterPeerClient.cs
+++ b/AgentKit.Api/Services/ClusterPeerClient.cs
@@ -1,0 +1,153 @@
+using System.Net.Http.Json;
+using AgentKit.Api.Models;
+using AgentKit.Api.Security;
+using Services.Configuration;
+
+namespace AgentKit.Api.Services;
+
+/// <inheritdoc/>
+public sealed class ClusterPeerClient : IClusterPeerClient
+{
+    /// <summary>
+    /// Name of the <see cref="IHttpClientFactory"/>-registered client used for every peer call —
+    /// see <c>Program.cs</c> for its short timeout (a slow/dead peer must not stall a job
+    /// submission for long).
+    /// </summary>
+    public const string HttpClientName = "AgentClusterPeers";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<ClusterPeerClient> _logger;
+
+    public ClusterPeerClient(IHttpClientFactory httpClientFactory, ILogger<ClusterPeerClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Builds a client pointed at <paramref name="peer"/>, authenticated with the peer's own
+    /// configured API key — the peer's <c>ApiKeyMiddleware</c> authenticates this exactly like any
+    /// other caller; clustering introduces no separate auth mechanism.
+    /// </summary>
+    private HttpClient CreateClient(ClusterPeerSettings peer)
+    {
+        // peer.BaseUrl is expected to be a bare authority (e.g. "https://192.168.1.50:7016",
+        // no path component), which Uri combines correctly with a relative request path
+        // regardless of a trailing slash — no manual normalization needed.
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        client.BaseAddress = new Uri(peer.BaseUrl, UriKind.Absolute);
+        client.DefaultRequestHeaders.Add(ApiKeyMiddleware.HeaderName, peer.ApiKey);
+        return client;
+    }
+
+    /// <inheritdoc/>
+    public async Task<int?> GetAvailableCapacityAsync(ClusterPeerSettings peer, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = CreateClient(peer);
+            using var response = await client.GetAsync("api/cluster/status", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Peer {Peer} status check returned {StatusCode}", peer.Name, response.StatusCode);
+                return null;
+            }
+
+            var status = await response.Content.ReadFromJsonAsync<ClusterStatus>(cancellationToken);
+            return status?.AvailableCapacity;
+        }
+        // A dead/unreachable peer or its own request timeout must never block job submission —
+        // treated the same as "no capacity". This also swallows the caller's own cancellation,
+        // an accepted simplification: a cancelled job-start request has bigger problems than one
+        // swallowed peer probe.
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or NotSupportedException)
+        {
+            _logger.LogWarning(ex, "Peer {Peer} unreachable during capacity check", peer.Name);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<Guid?> ForwardJobAsync(ClusterPeerSettings peer, string goalDescription, int? maxIterations, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = CreateClient(peer);
+            using var response = await client.PostAsJsonAsync(
+                "api/jobs",
+                new StartJobRequest { GoalDescription = goalDescription, MaxIterations = maxIterations },
+                cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Peer {Peer} rejected forwarded job ({StatusCode})", peer.Name, response.StatusCode);
+                return null;
+            }
+
+            var started = await response.Content.ReadFromJsonAsync<StartJobResponse>(cancellationToken);
+            return started?.JobId;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or NotSupportedException)
+        {
+            _logger.LogWarning(ex, "Failed to forward job to peer {Peer}", peer.Name);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<AgentJobStatus?> GetRemoteStatusAsync(ClusterPeerSettings peer, Guid peerJobId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = CreateClient(peer);
+            using var response = await client.GetAsync($"api/jobs/{peerJobId}", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            return await response.Content.ReadFromJsonAsync<AgentJobStatus>(cancellationToken);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or NotSupportedException)
+        {
+            _logger.LogWarning(ex, "Failed to get remote status from peer {Peer} for job {JobId}", peer.Name, peerJobId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<Stream?> GetRemoteResultZipAsync(ClusterPeerSettings peer, Guid peerJobId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = CreateClient(peer);
+            using var response = await client.GetAsync($"api/jobs/{peerJobId}/result", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var buffer = new MemoryStream();
+            await response.Content.CopyToAsync(buffer, cancellationToken);
+            buffer.Position = 0;
+            return buffer;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or NotSupportedException)
+        {
+            _logger.LogWarning(ex, "Failed to fetch remote result from peer {Peer} for job {JobId}", peer.Name, peerJobId);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> RequestRemoteStopAsync(ClusterPeerSettings peer, Guid peerJobId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = CreateClient(peer);
+            using var response = await client.PostAsync($"api/jobs/{peerJobId}/stop", content: null, cancellationToken);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or NotSupportedException)
+        {
+            _logger.LogWarning(ex, "Failed to stop remote job {JobId} on peer {Peer}", peerJobId, peer.Name);
+            return false;
+        }
+    }
+}

--- a/AgentKit.Api/Services/IAgentJobService.cs
+++ b/AgentKit.Api/Services/IAgentJobService.cs
@@ -5,35 +5,42 @@ namespace AgentKit.Api.Services;
 /// <summary>
 /// Runs goal-agent jobs headlessly: each job gets its own workspace directory and its own
 /// <c>GoalAgentService</c> instance, so many jobs can run concurrently without sharing state
-/// (unlike the dashboard's single-active-run model). A job's lifetime spans the process — see
-/// <see cref="GetPersistedStatusAsync"/> for the fallback once a job's process-local state is gone
-/// (server restart).
+/// (unlike the dashboard's single-active-run model). When this node is too busy for a new job and
+/// peers are configured (<c>AppConfiguration.Cluster.Peers</c>), it forwards the job to an idle
+/// peer instead — a job's id always identifies it to whichever node the caller originally talked
+/// to, regardless of which node actually runs it. See <see cref="GetStatusAsync"/> for the
+/// fallback once a job's process-local state is gone (server restart).
 /// </summary>
 public interface IAgentJobService
 {
     /// <summary>
-    /// Starts a new job in the background and returns its id immediately; the run itself
-    /// continues after this call returns (fire-and-forget, owned by this singleton service so it
-    /// outlives the HTTP request that started it).
+    /// Starts a new job — locally, or forwarded to an idle peer if this node is too busy and a
+    /// peer has room — and returns its id immediately; the run itself continues after this call
+    /// returns.
     /// </summary>
-    Guid StartJob(string goalDescription, int? maxIterations);
-
-    /// <summary>Live status of a job whose <c>GoalAgentService</c> instance is still tracked in this process, or null if unknown.</summary>
-    AgentJobStatus? GetStatus(Guid jobId);
+    Task<Guid> StartJobAsync(string goalDescription, int? maxIterations, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Status of a job read from the database instead of process memory — the fallback for a job
-    /// started by a prior process (e.g. before a restart). Returns null when no run history is
-    /// configured, or no such run exists.
+    /// Status of a job: live from this process's memory if it's running here, proxied from the
+    /// peer if it was forwarded, or read from this node's persisted history as a last resort.
+    /// Null if the job is unknown by all three.
     /// </summary>
-    Task<AgentJobStatus?> GetPersistedStatusAsync(Guid jobId);
+    Task<AgentJobStatus?> GetStatusAsync(Guid jobId, CancellationToken cancellationToken);
 
-    /// <summary>The job's workspace directory, or null if the job is unknown to this process.</summary>
-    string? GetWorkspacePath(Guid jobId);
+    /// <summary>
+    /// The job's finished workspace as a zip — built from local disk if it ran here, or fetched
+    /// from the peer if it was forwarded. Null if the job is unknown, still running, or its files
+    /// are unavailable (caller is expected to have already checked <see cref="GetStatusAsync"/>
+    /// for a terminal phase).
+    /// </summary>
+    Task<Stream?> GetResultZipAsync(Guid jobId, CancellationToken cancellationToken);
 
-    /// <summary>Requests the job stop at its next step boundary. Returns false if the job is unknown to this process.</summary>
-    bool RequestStop(Guid jobId);
+    /// <summary>
+    /// Requests the job stop at its next step boundary — locally, or by asking the peer it was
+    /// forwarded to. Returns false if the job is unknown to this process.
+    /// </summary>
+    Task<bool> RequestStopAsync(Guid jobId, CancellationToken cancellationToken);
 
-    /// <summary>Recent jobs (persisted history), newest first.</summary>
-    Task<IReadOnlyList<AgentJobSummary>> GetRecentJobsAsync(int count);
+    /// <summary>Recent jobs (this node's own persisted history), newest first.</summary>
+    Task<IReadOnlyList<AgentJobSummary>> GetRecentJobsAsync(int count, CancellationToken cancellationToken);
 }

--- a/AgentKit.Api/Services/IClusterPeerClient.cs
+++ b/AgentKit.Api/Services/IClusterPeerClient.cs
@@ -1,0 +1,38 @@
+using AgentKit.Api.Models;
+using Services.Configuration;
+
+namespace AgentKit.Api.Services;
+
+/// <summary>
+/// All outbound HTTP calls from this node to a peer <c>AgentKit.Api</c> node. Isolated behind an
+/// interface so <see cref="AgentJobService"/>'s forwarding decision can be unit-tested with a
+/// mock — no real network or LLM call involved in exercising that logic.
+/// </summary>
+public interface IClusterPeerClient
+{
+    /// <summary>
+    /// Asks <paramref name="peer"/> how much free capacity it currently has
+    /// (<c>GET /api/cluster/status</c>). Null means the peer is unreachable, misconfigured, or
+    /// returned something unexpected — callers should treat that the same as "no capacity".
+    /// </summary>
+    Task<int?> GetAvailableCapacityAsync(ClusterPeerSettings peer, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Starts a job on <paramref name="peer"/> on this node's behalf. Returns the peer's own job
+    /// id on success, or null if the peer rejected the request or is unreachable.
+    /// </summary>
+    Task<Guid?> ForwardJobAsync(ClusterPeerSettings peer, string goalDescription, int? maxIterations, CancellationToken cancellationToken);
+
+    /// <summary>Status of a job this node forwarded to <paramref name="peer"/>, or null if unreachable/not found.</summary>
+    Task<AgentJobStatus?> GetRemoteStatusAsync(ClusterPeerSettings peer, Guid peerJobId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The finished result zip of a job this node forwarded to <paramref name="peer"/>, fully
+    /// buffered into memory (same simplification as the local result path — jobs are expected to
+    /// produce at most a few MB), or null if unreachable/not ready/not found.
+    /// </summary>
+    Task<Stream?> GetRemoteResultZipAsync(ClusterPeerSettings peer, Guid peerJobId, CancellationToken cancellationToken);
+
+    /// <summary>Requests a stop on a job this node forwarded to <paramref name="peer"/>. Returns false if unreachable/not found.</summary>
+    Task<bool> RequestRemoteStopAsync(ClusterPeerSettings peer, Guid peerJobId, CancellationToken cancellationToken);
+}

--- a/AgentKit.Api/appsettings.json
+++ b/AgentKit.Api/appsettings.json
@@ -47,6 +47,9 @@
     },
     "Jobs": {
       "RootFolder": ""
+    },
+    "Cluster": {
+      "Peers": []
     }
   }
 }

--- a/Services/Configuration/AppConfiguration.cs
+++ b/Services/Configuration/AppConfiguration.cs
@@ -57,6 +57,44 @@ public class AppConfiguration
     /// Settings for headless goal-agent jobs (see <c>AgentKit.Api</c>'s job API).
     /// </summary>
     public JobsSettings Jobs { get; set; } = new();
+
+    /// <summary>
+    /// Other <c>AgentKit.Api</c> instances this node can forward jobs to when it's too busy to
+    /// take one itself. Empty (the default) means no clustering — every job runs locally.
+    /// </summary>
+    public ClusterSettings Cluster { get; set; } = new();
+}
+
+/// <summary>
+/// Peer <c>AgentKit.Api</c> nodes this instance can forward jobs to. A static list, not
+/// auto-discovered — see <see cref="ClusterPeerSettings"/>.
+/// </summary>
+public class ClusterSettings
+{
+    /// <summary>
+    /// Known peer nodes, in the order they're tried when this node is too busy for a new job.
+    /// Empty = clustering disabled; every job runs locally regardless of load.
+    /// </summary>
+    public List<ClusterPeerSettings> Peers { get; set; } = new();
+}
+
+/// <summary>
+/// One peer <c>AgentKit.Api</c> node this instance may forward jobs to.
+/// </summary>
+public class ClusterPeerSettings
+{
+    /// <summary>Friendly name for logging/identification, e.g. "office-pc".</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Base URL of the peer, e.g. "https://192.168.1.50:7016".</summary>
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The <em>peer's own</em> API key — what this node presents as its <c>X-API-Key</c> header
+    /// when calling the peer, not this node's own key. The peer authenticates the call the same
+    /// way it authenticates any other caller; clustering adds no new auth mechanism.
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Phase 2 of the AgentKit.Api job API: a node forwards a whole job to an idle peer (another
  instance of this same API) when its own LLM pool is saturated, instead of queuing it locally.
- New `Cluster:Peers` config (base URL + peer's own API key per peer). Empty by default —
  clustering is entirely opt-in, zero overhead for a single-node deployment.
- New `GET /api/cluster/status` endpoint reports local pool capacity; a node asks a peer's own
  status before forwarding, and only forwards if that peer reports room.
- `IAgentJobService` is now fully async; a job tracked as forwarded transparently proxies
  status/result/stop calls to the peer that actually ran it, so callers never need to know which
  node handled their job.
- All outbound peer HTTP is isolated behind `IClusterPeerClient`, mockable in tests — the
  routing decision (forward vs. run locally, which peer, fallback on failure) is fully
  unit-tested without any real network or LLM call.
- Distribution model is overflow forwarding only (one job always runs entirely on one node);
  splitting a single job's work across multiple peers is deferred.

## Test plan
- [x] All 17 projects build clean (0 warnings/errors)
- [x] All 6 test suites pass (1225 tests total, including new routing-decision tests)
- [x] Verified live: started two real AgentKit.Api instances on different ports, peered at each
      other, confirmed `/api/cluster/status` is reachable cross-node and correctly rejects
      requests without the right API key — no `/api/jobs` request was ever sent, so no LLM
      was invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
